### PR TITLE
Decay argument types in call to do_check_format_string

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3466,7 +3466,7 @@ template <typename Char, Char... CHARS> class udl_formatter {
   std::basic_string<Char> operator()(Args&&... args) const {
     FMT_CONSTEXPR_DECL Char s[] = {CHARS..., '\0'};
     FMT_CONSTEXPR_DECL bool invalid_format =
-        do_check_format_string<Char, error_handler, Args...>(
+        do_check_format_string<Char, error_handler, typename std::decay<Args>::type...>(
             basic_string_view<Char>(s, sizeof...(CHARS)));
     (void)invalid_format;
     return format(s, std::forward<Args>(args)...);


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

This change fixes Issue #1292 which causes the UDL template based formatter to fail when passed and lvalue to a user defined type despite an appropriate custom formatter being available.